### PR TITLE
Feat mingrui excalidraw action

### DIFF
--- a/packages/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
+++ b/packages/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
@@ -41,7 +41,7 @@ import {
   MindmapElementModel,
   NoteBlockModel,
   NoteDisplayMode,
-  type ShapeElementModel,
+  ShapeElementModel,
 } from '@blocksuite/affine-model';
 import {
   EditPropsStore,
@@ -361,7 +361,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           this._move('ArrowRight', true);
         },
 
-        Enter: () => {
+        Enter: ctx => {
           const { service } = rootComponent;
           const selection = service.selection;
           const elements = selection.selectedElements;
@@ -394,6 +394,12 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
                 textBlock.tryFocusEnd();
               }
 
+              return;
+            }
+
+            if (element instanceof ShapeElementModel && !selection.editing) {
+              ctx.get('keyboardState').event.preventDefault();
+              mountShapeTextEditor(element, rootComponent);
               return;
             }
           }
@@ -456,7 +462,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
               );
             }
           });
-        },
+        }
       },
       {
         global: true,

--- a/packages/affine/blocks/root/src/edgeless/shape-preview-overlay.ts
+++ b/packages/affine/blocks/root/src/edgeless/shape-preview-overlay.ts
@@ -1,0 +1,117 @@
+import {
+  getSurfaceComponent,
+  Overlay,
+  type RoughCanvas,
+} from '@blocksuite/affine-block-surface';
+import { ShapeFactory } from '@blocksuite/affine-gfx-shape';
+import {
+  DefaultTheme,
+  ShapeElementModel,
+  shapeMethods,
+  type ShapeType,
+} from '@blocksuite/affine-model';
+import { Bound, type IVec } from '@blocksuite/global/gfx';
+import type { GfxController } from '@blocksuite/std/gfx';
+
+import { Direction } from '../../../../widgets/edgeless-selected-rect/src/utils.js';
+
+/**
+ * Overlay for showing shape preview when using keyboard shortcuts
+ */
+export class ShapePreviewOverlay extends Overlay {
+  private _previewShapes: Map<Direction, {
+    bound: Bound;
+    shapeType: ShapeType;
+    stroke: string;
+    connectorPath?: IVec[];
+    originalBound?: Bound;
+  }> = new Map();
+
+  constructor(gfx: GfxController) {
+    super(gfx);
+  }
+
+  /**
+   * Add a preview shape in the specified direction
+   */
+  addPreviewShape(
+    direction: Direction,
+    bound: Bound,
+    shapeType: ShapeType,
+    stroke: string,
+    connectorPath?: IVec[],
+    originalBound?: Bound
+  ) {
+    this._previewShapes.set(direction, { bound, shapeType, stroke, connectorPath, originalBound });
+    this._refreshSurface();
+  }
+
+  /**
+   * Remove preview shape in the specified direction
+   */
+  removePreviewShape(direction: Direction) {
+    this._previewShapes.delete(direction);
+    this._refreshSurface();
+  }
+
+  /**
+   * Clear all preview shapes
+   */
+  clearAllPreviews() {
+    this._previewShapes.clear();
+    this._refreshSurface();
+  }
+
+  /**
+   * Check if there are any preview shapes
+   */
+  hasPreviewShapes(): boolean {
+    return this._previewShapes.size > 0;
+  }
+
+  private _refreshSurface() {
+    const surface = getSurfaceComponent(this.gfx.std);
+    if (surface) {
+      surface.refresh();
+    }
+  }
+
+  override render(ctx: CanvasRenderingContext2D, _rc: RoughCanvas) {
+    if (this._previewShapes.size === 0) return;
+
+    this._previewShapes.forEach(({ bound, shapeType, stroke, connectorPath }) => {
+      ctx.save();
+      
+      // Set dashed line style for preview shapes
+      ctx.setLineDash([4, 4]);
+      ctx.globalAlpha = 0.6;
+      ctx.strokeStyle = stroke;
+      ctx.lineWidth = 2;
+      ctx.fillStyle = 'transparent';
+      
+      // Draw the connector path first if it exists
+      if (connectorPath && connectorPath.length > 1) {
+        ctx.beginPath();
+        ctx.moveTo(connectorPath[0][0], connectorPath[0][1]);
+        for (let i = 1; i < connectorPath.length; i++) {
+          ctx.lineTo(connectorPath[i][0], connectorPath[i][1]);
+        }
+        ctx.stroke();
+      }
+      
+      // Draw the preview shape using the shape methods
+      shapeMethods[shapeType].draw(ctx, {
+        x: bound.x,
+        y: bound.y,
+        w: bound.w,
+        h: bound.h,
+        rotate: 0,
+      });
+      
+      // Stroke the path
+      ctx.stroke();
+      
+      ctx.restore();
+    });
+  }
+} 


### PR DESCRIPTION
This commit primarily implements the canvas element navigation feature using Alt/Option + Arrow keys. Based on the provided graph traversal algorithm, we introduced a stateful navigation mechanism, including:
State Management: Maintained navigation session (isExploring), visited nodes (visitedNodes), last navigation direction (lastDirection), and a list of sibling nodes in the same direction (siblingNodes and siblingIndex) to support cycling through multiple connected nodes.
Improved Traversal Logic: Refactored the core graph traversal functions to prioritize unvisited successor nodes, and fall back to selecting predecessor nodes by direction when all successors have been visited.
Connector Path Data Correction: Fixed a runtime error where the points property was undefined when accessing ConnectorElementModel, switching to the correct path property instead.
Algorithm Documentation Comments: Added the content of "Graph Traversal Algorithm.md" as code comments for better understanding and maintenance.
These improvements ensure the accuracy, robustness, and user experience when navigating elements connected by lines on the canvas.